### PR TITLE
fix mscl-type import

### DIFF
--- a/assembly/address.ts
+++ b/assembly/address.ts
@@ -1,4 +1,4 @@
-import {Valider, ByteArray} from 'mscl-type';
+import {Valider, ByteArray} from 'mscl-type/assembly/index';
 
 /**
  * A Massa's blockchain address.


### PR DESCRIPTION
this helps compile the current version of massa-sc-examples/mrc